### PR TITLE
Bump upper bound for base to <4.9

### DIFF
--- a/pipes-interleave.cabal
+++ b/pipes-interleave.cabal
@@ -18,7 +18,7 @@ source-repository head
 
 library
   exposed-modules:     Pipes.Interleave
-  build-depends:       base >=4.6 && <4.8,
+  build-depends:       base >=4.6 && <4.9,
                        containers >=0.5 && < 0.6,
                        pipes >=4.0 && <4.2
   default-language:    Haskell2010


### PR DESCRIPTION
Otherwise it won't build on ghc 7.10 ;)
